### PR TITLE
reduce image size with multi-stage builds

### DIFF
--- a/alpine-vim-base/Dockerfile
+++ b/alpine-vim-base/Dockerfile
@@ -17,7 +17,7 @@ RUN apk add --no-cache \
     make \
     ncurses-dev \
     python \
-    python-dev \
+    python-dev
 
 # Build vim from git source
 RUN git clone https://github.com/vim/vim \
@@ -27,15 +27,14 @@ RUN git clone https://github.com/vim/vim \
     --disable-netbeans \
     --enable-multibyte \
     --enable-pythoninterp \
-    --prefix /tmp/build \
     --with-features=big \
     --with-python-config-dir=/usr/lib/python2.7/config \
  && make install
  
  FROM alpin:latest
  
- COPY --from=builder /tmp/build/bin/ /usr/bin
- COPY --from=builder /tmp/build/share/vim/ /usr/share/vim/
+ COPY --from=builder /usr/local/bin/ /usr/local/bin
+ COPY --from=builder /usr/local/share/vim/ /usr/local/share/vim/
  # NOTE: man page is ignored
  
  RUN apk add --no-cache \

--- a/alpine-vim-base/Dockerfile
+++ b/alpine-vim-base/Dockerfile
@@ -1,8 +1,13 @@
-FROM alpine:latest
+# Multistage builds to reduce image size to ~37MB
+# by tuanhtrng
+FROM alpine:latest as builder
 
 MAINTAINER JAremko <w3techplaygound@gmail.com>
 
-RUN apk add --update --virtual build-deps \
+WORKDIR /tmp
+
+# Install dependencies
+RUN apk add --no-cache \
     build-base \
     ctags \
     git \
@@ -13,31 +18,31 @@ RUN apk add --update --virtual build-deps \
     ncurses-dev \
     python \
     python-dev \
-# Build Vim
-    && cd /tmp \
-    && git clone https://github.com/vim/vim \
-    && cd /tmp/vim \
-    && ./configure \
+
+# Build vim from git source
+RUN git clone https://github.com/vim/vim \
+ && cd vim \
+ && ./configure \
     --disable-gui \
     --disable-netbeans \
     --enable-multibyte \
     --enable-pythoninterp \
-    --prefix /usr \
+    --prefix /tmp/build \
     --with-features=big \
     --with-python-config-dir=/usr/lib/python2.7/config \
-    && make install \
-    && apk del build-deps \
-    && apk add \
+ && make install
+ 
+ FROM alpin:latest
+ 
+ COPY --from=builder /tmp/build/bin/ /usr/bin
+ COPY --from=builder /tmp/build/share/vim/ /usr/share/vim/
+ # NOTE: man page is ignored
+ 
+ RUN apk add --no-cache \
     libice \
     libsm \
     libx11 \
     libxt \
-    ncurses \
-# Cleanup
-    && rm -rf \
-    /var/cache/* \
-    /var/log/* \
-    /var/tmp/* \
-    && mkdir /var/cache/apk
+    ncurses
 
 ENTRYPOINT ["vim"]


### PR DESCRIPTION
Got the image size down to 37MB from 184MB.

Tested on Debian Stretch, docker client 18.01.0-ce.